### PR TITLE
Add `BroadcastChannel`

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,10 @@ The `MessageChannel` class. See below.
 
 The `MessagePort` class. See below.
 
+#### `Worker.BroadcastChannel`
+
+The `BroadcastChannel` class. See below.
+
 #### `Worker.preload(entry)`
 
 Register the module at `entry` to be loaded in every worker before its own entry module runs. Preloads are inherited by nested workers.
@@ -147,6 +151,40 @@ Emitted for each message received on the port. The message value is passed to th
 #### `event: 'close'`
 
 Emitted when the port has closed.
+
+### `BroadcastChannel`
+
+A named channel for broadcasting messages to every other `BroadcastChannel` with the same name across the entire worker tree, including the main thread and nested workers. `BroadcastChannel` extends `EventEmitter` and follows the semantics of the Web `BroadcastChannel`: a channel never receives its own messages, but every other channel sharing its name does.
+
+```js
+const Worker = require('bare-worker')
+
+const channel = new Worker.BroadcastChannel('updates')
+
+channel.on('message', console.log)
+
+channel.postMessage('Hello everyone')
+```
+
+#### `const channel = new BroadcastChannel(name)`
+
+Create a channel bound to `name`. All channels constructed with the same `name`, in any thread of the worker tree, are connected.
+
+#### `channel.name`
+
+The name the channel is bound to.
+
+#### `channel.postMessage(message)`
+
+Broadcast `message` to every other connected channel sharing this channel's name. The message is cloned; unlike `MessagePort.postMessage()`, transferring is not supported. Throws if the channel has been closed.
+
+#### `channel.close()`
+
+Close the channel, disconnecting it from the others. No further messages will be sent or received.
+
+#### `event: 'message'`
+
+Emitted for each message broadcast to the channel by another channel sharing its name. The message value is passed to the listener.
 
 ## License
 

--- a/global.js
+++ b/global.js
@@ -1,4 +1,5 @@
-const { MessageChannel, MessagePort } = require('.')
+const { MessageChannel, MessagePort, BroadcastChannel } = require('.')
 
 global.MessageChannel = MessageChannel
 global.MessagePort = MessagePort
+global.BroadcastChannel = BroadcastChannel

--- a/index.js
+++ b/index.js
@@ -1,12 +1,15 @@
 const Thread = require('bare-thread')
 const Channel = require('bare-channel')
+const Broadcast = require('bare-broadcast-channel')
 const WorkerState = require('./lib/worker-state')
 const MessageChannel = require('./lib/message-channel')
 const MessagePort = require('./lib/message-port')
+const BroadcastChannel = require('./lib/broadcast-channel')
 const constants = require('./lib/constants')
 
 const preloads = new Map()
 
+let broadcast = null
 let environmentData = new Map()
 let parentPort = null
 let workerData = null
@@ -16,10 +19,17 @@ if (WorkerState.parent) {
     preloads.set(entry, source)
   }
 
+  broadcast = WorkerState.parent.broadcast
   parentPort = WorkerState.parent.port
   workerData = WorkerState.parent.data
   environmentData = WorkerState.parent.environmentData
+} else {
+  broadcast = new Broadcast()
 }
+
+// Every named broadcast channel on this thread connects to the same underlying
+// channel, which is shared across the whole worker tree.
+BroadcastChannel._channel = broadcast
 
 const worker = Thread.prepare(require.resolve('./lib/worker-thread'), { shared: true })
 
@@ -37,6 +47,7 @@ module.exports = exports = class Worker extends MessagePort {
       data: {
         source: Thread.prepare(entry, { shared: true }),
         channel: channel.handle,
+        broadcast: broadcast.handle,
         data: workerData,
         preloads,
         environmentData
@@ -97,6 +108,7 @@ exports.Worker = exports
 
 exports.MessageChannel = MessageChannel
 exports.MessagePort = MessagePort
+exports.BroadcastChannel = BroadcastChannel
 
 exports.parentPort = parentPort
 exports.workerData = workerData

--- a/lib/broadcast-channel.js
+++ b/lib/broadcast-channel.js
@@ -1,0 +1,86 @@
+const EventEmitter = require('bare-events')
+const errors = require('./errors')
+
+module.exports = exports = class BroadcastChannel extends EventEmitter {
+  constructor(name) {
+    super()
+
+    this.name = String(name)
+
+    this._port = exports._channel.connect()
+    this._inflight = 0
+    this._closed = false
+
+    // An idle channel without listeners should not hold the thread alive.
+    this._port.unref()
+
+    this.on('newListener', this._onnewlistener).on('removeListener', this._onremovelistener)
+
+    this._read()
+  }
+
+  postMessage(message) {
+    if (this._closed) {
+      throw errors.CHANNEL_CLOSED('BroadcastChannel is closed')
+    }
+
+    this._write(message)
+  }
+
+  close() {
+    if (this._closed) return
+
+    this._closed = true
+
+    this._port.close()
+  }
+
+  [Symbol.for('bare.inspect')]() {
+    return {
+      __proto__: { constructor: BroadcastChannel },
+
+      name: this.name
+    }
+  }
+
+  async _write(message) {
+    this._inflight++
+    this._port.ref()
+
+    try {
+      await this._port.write({ name: this.name, message })
+    } finally {
+      this._inflight--
+      this._unref()
+    }
+  }
+
+  _unref() {
+    if (this._inflight === 0 && this.listenerCount('message') === 0) this._port.unref()
+  }
+
+  async _read() {
+    for await (const data of this._port) {
+      // The channel shares a single underlying broadcast channel across the
+      // whole worker tree, so messages are tagged with their channel name and
+      // filtered on read.
+      if (data.name === this.name) this.emit('message', data.message)
+    }
+  }
+
+  _onnewlistener(name) {
+    if (name !== 'message') return
+
+    if (this.listenerCount('message') === 0) this._port.ref()
+  }
+
+  _onremovelistener(name) {
+    if (name !== 'message') return
+
+    if (this.listenerCount('message') === 0) this._unref()
+  }
+
+  // The underlying broadcast channel shared by every named channel on this
+  // thread. Set when the worker module is loaded.
+  static _channel = null
+}

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -14,4 +14,8 @@ module.exports = class WorkerError extends Error {
   static ALREADY_STARTED(msg) {
     return new WorkerError(msg, WorkerError.ALREADY_STARTED)
   }
+
+  static CHANNEL_CLOSED(msg) {
+    return new WorkerError(msg, WorkerError.CHANNEL_CLOSED)
+  }
 }

--- a/lib/worker-state.js
+++ b/lib/worker-state.js
@@ -1,4 +1,5 @@
 const Channel = require('bare-channel')
+const Broadcast = require('bare-broadcast-channel')
 const MessagePort = require('./message-port')
 
 const state = Symbol.for('bare.worker.state')
@@ -6,7 +7,7 @@ const kind = Symbol.for('bare.worker.state.kind')
 
 module.exports = class WorkerState {
   static get [kind]() {
-    return 0 // Compatibility version
+    return 1 // Compatibility version
   }
 
   static get parent() {
@@ -20,12 +21,20 @@ module.exports = class WorkerState {
   }
 
   constructor() {
-    const { source, preloads, data, environmentData, channel: handle } = Bare.Thread.self.data
+    const {
+      source,
+      preloads,
+      data,
+      environmentData,
+      channel: handle,
+      broadcast: broadcastHandle
+    } = Bare.Thread.self.data
 
     this.source = source
     this.preloads = preloads
     this.data = Bare.Thread.self.data = data
     this.environmentData = environmentData
+    this.broadcast = Broadcast.from(broadcastHandle)
 
     const channel = Channel.from(handle, { interfaces: [MessagePort] })
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "./constants": "./lib/constants.js",
     "./errors": "./lib/errors.js",
     "./message-channel": "./lib/message-channel.js",
-    "./message-port": "./lib/message-port.js"
+    "./message-port": "./lib/message-port.js",
+    "./broadcast-channel": "./lib/broadcast-channel.js"
   },
   "files": [
     "index.js",
@@ -32,6 +33,7 @@
   },
   "homepage": "https://github.com/holepunchto/bare-worker#readme",
   "dependencies": {
+    "bare-broadcast-channel": "^0.1.0",
     "bare-channel": "^5.1.5",
     "bare-events": "^2.2.1",
     "bare-module": "^6.0.1",

--- a/test.js
+++ b/test.js
@@ -112,6 +112,184 @@ test('message port ref, unref and hasRef', (t) => {
   t.is(port.hasRef(), false)
 })
 
+test('broadcast channel from worker to main', (t) => {
+  t.plan(2)
+
+  // Connect the receiving end before spawning the worker so it is already a
+  // peer by the time the worker broadcasts.
+  const channel = new Worker.BroadcastChannel('test')
+
+  channel.on('message', (message) => {
+    t.is(message, 'Hello broadcast')
+    channel.close()
+  })
+
+  const worker = new Worker(require.resolve('./test/fixtures/broadcast'))
+
+  worker.on('exit', (exitCode) => t.is(exitCode, 0))
+})
+
+test('broadcast channel from main to worker', (t) => {
+  t.plan(2)
+
+  const channel = new Worker.BroadcastChannel('test')
+
+  const worker = new Worker(require.resolve('./test/fixtures/broadcast-relay'))
+
+  worker
+    .on('message', (message) => {
+      // The worker echoes back over its parent port once it receives the
+      // broadcast, confirming delivery from the main thread.
+      if (message === 'ready') {
+        channel.postMessage('Hello worker')
+      } else {
+        t.is(message, 'Hello worker')
+        channel.close()
+      }
+    })
+    .on('exit', (exitCode) => t.is(exitCode, 0))
+})
+
+test('broadcast channel from worker to worker', (t) => {
+  t.plan(2)
+
+  const receiver = new Worker(require.resolve('./test/fixtures/broadcast-relay'))
+
+  receiver.on('message', (message) => {
+    // Only spawn the sender once the receiver is connected, so it does not miss
+    // the broadcast.
+    if (message === 'ready') {
+      const sender = new Worker(require.resolve('./test/fixtures/broadcast'))
+
+      sender.on('exit', (exitCode) => t.is(exitCode, 0))
+    } else {
+      t.is(message, 'Hello broadcast')
+    }
+  })
+})
+
+test('broadcast channel reaches nested workers', (t) => {
+  t.plan(1)
+
+  const channel = new Worker.BroadcastChannel('test')
+
+  channel.on('message', (message) => {
+    t.is(message, 'Hello broadcast')
+    channel.close()
+  })
+
+  new Worker(require.resolve('./test/fixtures/broadcast-nested'))
+})
+
+test('broadcast channel does not receive its own messages', (t) => {
+  t.plan(1)
+
+  const a = new Worker.BroadcastChannel('room-self')
+  const b = new Worker.BroadcastChannel('room-self')
+
+  a.on('message', () => t.fail('a received its own message'))
+
+  b.on('message', (message) => {
+    t.is(message, 'ping')
+    a.close()
+    b.close()
+  })
+
+  a.postMessage('ping')
+})
+
+test('broadcast channel ignores messages for other names', (t) => {
+  t.plan(1)
+
+  const a = new Worker.BroadcastChannel('room-names')
+  const b = new Worker.BroadcastChannel('room-names')
+  const other = new Worker.BroadcastChannel('other-name')
+
+  other.on('message', () => t.fail('channel received a message for another name'))
+
+  b.on('message', (message) => {
+    t.is(message, 'ping')
+    a.close()
+    b.close()
+    other.close()
+  })
+
+  a.postMessage('ping')
+})
+
+test('broadcast channel delivers multiple messages in order', (t) => {
+  t.plan(1)
+
+  const a = new Worker.BroadcastChannel('room-order')
+  const b = new Worker.BroadcastChannel('room-order')
+
+  const received = []
+
+  b.on('message', (message) => {
+    received.push(message)
+
+    if (received.length === 3) {
+      t.alike(received, [1, 2, 3])
+      a.close()
+      b.close()
+    }
+  })
+
+  a.postMessage(1)
+  a.postMessage(2)
+  a.postMessage(3)
+})
+
+test('broadcast channel stops receiving after close', (t) => {
+  t.plan(1)
+
+  const a = new Worker.BroadcastChannel('room-closed')
+  const b = new Worker.BroadcastChannel('room-closed')
+  const c = new Worker.BroadcastChannel('room-closed')
+
+  b.close()
+  b.on('message', () => t.fail('closed channel received a message'))
+
+  c.on('message', (message) => {
+    t.is(message, 'ping')
+    a.close()
+    c.close()
+  })
+
+  a.postMessage('ping')
+})
+
+test('broadcast channel coerces its name to a string', (t) => {
+  t.plan(1)
+
+  const channel = new Worker.BroadcastChannel(42)
+
+  t.is(channel.name, '42')
+
+  channel.close()
+})
+
+test('broadcast channel throws when posting after close', (t) => {
+  t.plan(1)
+
+  const channel = new Worker.BroadcastChannel('closed-throw')
+
+  channel.close()
+
+  t.exception(() => channel.postMessage('nope'))
+})
+
+test('broadcast channel can be closed more than once', (t) => {
+  t.plan(1)
+
+  const channel = new Worker.BroadcastChannel('closed-twice')
+
+  channel.close()
+  channel.close()
+
+  t.pass()
+})
+
 test('class identity matches', (t) => {
   t.plan(4)
 

--- a/test/fixtures/broadcast-nested.js
+++ b/test/fixtures/broadcast-nested.js
@@ -1,0 +1,7 @@
+const Worker = require('bare-worker')
+
+// Spawn a nested worker that broadcasts, exercising handle propagation through
+// more than one level of the worker tree.
+const worker = new Worker(require.resolve('./broadcast'))
+
+worker.on('exit', () => Bare.exit())

--- a/test/fixtures/broadcast-relay.js
+++ b/test/fixtures/broadcast-relay.js
@@ -1,0 +1,11 @@
+const { parentPort, BroadcastChannel } = require('bare-worker')
+
+const channel = new BroadcastChannel('test')
+
+channel.on('message', (message) => {
+  parentPort.postMessage(message)
+  channel.close()
+})
+
+// Signal that the channel is connected so the other end can safely broadcast.
+parentPort.postMessage('ready')

--- a/test/fixtures/broadcast.js
+++ b/test/fixtures/broadcast.js
@@ -1,0 +1,5 @@
+const { BroadcastChannel } = require('bare-worker')
+
+const channel = new BroadcastChannel('test')
+
+channel.postMessage('Hello broadcast')


### PR DESCRIPTION
The implementation is intentionally naïve and uses a single, shared `BroadcastChannel` across the entire worker tree and then filters messages by name. It gets the ball rolling, however.

Closes #17